### PR TITLE
Removed references to ECPoint outside of .jvm scope

### DIFF
--- a/crypto-test/src/test/scala/org/bitcoins/crypto/ECPublicKeyTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/ECPublicKeyTest.scala
@@ -31,10 +31,14 @@ class ECPublicKeyTest extends BitcoinSUnitTest {
   }
 
   it must "have serialization symmetry from ECPublicKey -> ECPoint -> ECPublicKey" in {
-    forAll(CryptoGenerators.publicKey) { pubKey =>
-      val p = pubKey.toPoint
-      val pub2 = ECPublicKey.fromPoint(p, pubKey.isCompressed)
-      assert(pubKey == pub2)
+    CryptoContext.cryptoRuntime match {
+      case _: BouncycastleCryptoRuntime | _: LibSecp256k1CryptoRuntime =>
+        forAll(CryptoGenerators.publicKey) { pubKey =>
+          val p = BouncyCastleUtil.decodePoint(pubKey)
+          val pub2 = BouncyCastleUtil.decodePubKey(p, pubKey.isCompressed)
+          assert(pubKey == pub2)
+        }
+      case _ => succeed
     }
   }
 

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
@@ -52,8 +52,8 @@ trait BouncycastleCryptoRuntime extends CryptoRuntime {
         s"Field element cannot have more than 32 bytes, got $bytes from $x")
     }
 
-    (ECPublicKey(0x02.toByte +: bytes32).toPoint,
-     ECPublicKey(0x03.toByte +: bytes32).toPoint)
+    (BouncyCastleUtil.decodePoint(ECPublicKey(0x02.toByte +: bytes32)),
+     BouncyCastleUtil.decodePoint(ECPublicKey(0x03.toByte +: bytes32)))
   }
 
   override def recoverPublicKey(
@@ -76,8 +76,8 @@ trait BouncycastleCryptoRuntime extends CryptoRuntime {
       .subtract(curve.getG.multiply(m))
       .multiply(r.modInverse(curve.getN))
 
-    val pub1 = ECPublicKey.fromPoint(Q1)
-    val pub2 = ECPublicKey.fromPoint(Q2)
+    val pub1 = BouncyCastleUtil.decodePubKey(Q1)
+    val pub2 = BouncyCastleUtil.decodePubKey(Q2)
     (pub1, pub2)
   }
 
@@ -166,9 +166,10 @@ trait BouncycastleCryptoRuntime extends CryptoRuntime {
   }
 
   override def add(pk1: ECPublicKey, pk2: ECPublicKey): ECPublicKey = {
-    val sumPoint = pk1.toPoint.add(pk2.toPoint)
+    val sumPoint =
+      BouncyCastleUtil.decodePoint(pk1).add(BouncyCastleUtil.decodePoint(pk2))
 
-    ECPublicKey.fromPoint(sumPoint)
+    BouncyCastleUtil.decodePubKey(sumPoint)
   }
 
   def pubKeyTweakAdd(
@@ -231,7 +232,7 @@ trait BouncycastleCryptoRuntime extends CryptoRuntime {
         val sigPoint = s.publicKey
         val challengePoint = schnorrPubKey.publicKey.tweakMultiply(negE)
         val computedR = challengePoint.add(sigPoint)
-        val yCoord = computedR.toPoint.getRawYCoord
+        val yCoord = BouncyCastleUtil.decodePoint(computedR).getRawYCoord
 
         yCoord != null && !yCoord.testBitZero() && computedR.schnorrNonce == rx
       case Failure(_) => false

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.crypto
 
-import org.bouncycastle.math.ec.ECPoint
-
 import java.math.BigInteger
 import scodec.bits.ByteVector
 
@@ -105,7 +103,8 @@ sealed abstract class ECPrivateKey
   }
 
   def negate: ECPrivateKey = {
-    val negPrivKeyNum = CryptoParams.curve.getN
+    val negPrivKeyNum = new BigInteger( // CryptoParams.curve.getN
+      "115792089237316195423570985008687907852837564279074904382605163141518161494337")
       .subtract(new BigInteger(1, bytes.toArray))
     ECPrivateKey(ByteVector(negPrivKeyNum.toByteArray))
   }
@@ -256,15 +255,6 @@ sealed abstract class ECPublicKey extends BaseECKey {
   def decompressed: ECPublicKey =
     CryptoContext.cryptoRuntime.decompressed(this)
 
-  /** Decodes a [[org.bitcoins.crypto.ECPublicKey ECPublicKey]] in bitcoin-s
-    * to a [[org.bouncycastle.math.ec.ECPoint ECPoint]] data structure that is internal to the
-    * bouncy castle library
-    * @return
-    */
-  def toPoint: ECPoint = {
-    BouncyCastleUtil.decodePoint(bytes)
-  }
-
   /** Adds this ECPublicKey to another as points and returns the resulting ECPublicKey.
     *
     * Note: if this ever becomes a bottleneck, secp256k1_ec_pubkey_combine should
@@ -315,12 +305,4 @@ object ECPublicKey extends Factory[ECPublicKey] {
     * [[https://github.com/bitcoin/bitcoin/blob/27765b6403cece54320374b37afb01a0cfe571c3/src/pubkey.h#L158]]
     */
   def isValid(bytes: ByteVector): Boolean = bytes.nonEmpty
-
-  /** Creates a [[org.bitcoins.crypto.ECPublicKey ECPublicKey]] from the
-    * [[org.bouncycastle.math.ec.ECPoint ECPoint]] data structure used internally inside of Bouncy Castle
-    */
-  def fromPoint(p: ECPoint, isCompressed: Boolean = true): ECPublicKey = {
-    val bytes = p.getEncoded(isCompressed)
-    ECPublicKey.fromBytes(ByteVector(bytes))
-  }
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/FieldElement.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/FieldElement.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.crypto
 
-import org.bouncycastle.math.ec.ECPoint
-
 import java.math.BigInteger
 import scodec.bits.ByteVector
 
@@ -52,8 +50,6 @@ case class FieldElement(bytes: ByteVector) extends NetworkElement {
     FieldElement.negate(this)
   }
 
-  def getPoint: ECPoint = FieldElement.computePoint(this)
-
   def getPublicKey: ECPublicKey = toPrivateKey.publicKey
 
   def inverse: FieldElement = FieldElement.computeInverse(this)
@@ -92,8 +88,13 @@ object FieldElement extends Factory[FieldElement] {
   val nMinusOne: FieldElement = FieldElement(
     "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140")
 
-  private val G: ECPoint = CryptoParams.curve.getG
-  private val N: BigInteger = CryptoParams.curve.getN
+  // CryptoParams.curve.getG
+  private val G: ECPublicKey = ECPublicKey(
+    "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+
+  // CryptoParams.curve.getN
+  private val N: BigInteger = new BigInteger(
+    "115792089237316195423570985008687907852837564279074904382605163141518161494337")
 
   private def getBigInteger(bytes: ByteVector): BigInteger = {
     new BigInteger(1, bytes.toArray)
@@ -120,7 +121,7 @@ object FieldElement extends Factory[FieldElement] {
     FieldElement(neg)
   }
 
-  def computePoint(fe: FieldElement): ECPoint = G.multiply(fe.toBigInteger)
+  def computePoint(fe: FieldElement): ECPublicKey = G.tweakMultiply(fe)
 
   /** Computes the inverse (mod M) of the input using the Euclidean Algorithm (log time)
     * Cribbed from [[https://www.geeksforgeeks.org/multiplicative-inverse-under-modulo-m/]]


### PR DESCRIPTION
I believe that the only remaining bouncy castle references that are problematic is the SipHash implementation in `GCS.scala` which needs to be pulled up alongside sha256, which I'll leave to you if that's okay.